### PR TITLE
Jenkinsfile: un-comment testing on Jenkins core LTS 2.479.1…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,11 +3,19 @@
  * https://github.com/jenkins-infra/pipeline-library/
  */
 buildPlugin(useContainerAgent: true, configurations: [
-  // Test the common case (i.e., a recent LTS release) on both Linux and Windows.
+  // Test the common case (i.e., a recent LTS release) on both Linux and Windows
+  // with same core version as the lowest baseline requested by pom.xml
   [ platform: 'linux', jdk: '11', jenkins: '2.361.1' ],
   [ platform: 'windows', jdk: '11', jenkins: '2.361.1' ],
 
   // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
   // see also https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/
-  [ platform: 'linux', jdk: '17', jenkins: '2.361.2' ],
+  // NOTE: 2.475+ introduced other breaking changes to ecosystem
+  //[ platform: 'linux', jdk: '17', jenkins: '2.479.1' ],
+
+  // NOTE: LTS https://www.jenkins.io/changelog-stable/#v2.462.3
+  // is the last LTS release to support Java 11
+  [ platform: 'linux', jdk: '11', jenkins: '2.462.3' ],
+  [ platform: 'linux', jdk: '17', jenkins: '2.462.3' ],
+  [ platform: 'linux', jdk: '21', jenkins: '2.462.3' ],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ buildPlugin(useContainerAgent: true, configurations: [
   // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
   // see also https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/
   // NOTE: 2.475+ introduced other breaking changes to ecosystem
-  //[ platform: 'linux', jdk: '17', jenkins: '2.479.1' ],
+  [ platform: 'linux', jdk: '17', jenkins: '2.479.1' ],
 
   // NOTE: LTS https://www.jenkins.io/changelog-stable/#v2.462.3
   // is the last LTS release to support Java 11

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,17 +5,10 @@
 buildPlugin(useContainerAgent: true, configurations: [
   // Test the common case (i.e., a recent LTS release) on both Linux and Windows
   // with same core version as the lowest baseline requested by pom.xml
-  [ platform: 'linux', jdk: '11', jenkins: '2.361.1' ],
-  [ platform: 'windows', jdk: '11', jenkins: '2.361.1' ],
+  [ platform: 'linux', jdk: '17', jenkins: '2.479.1' ],
+  [ platform: 'windows', jdk: '17', jenkins: '2.479.1' ],
 
   // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
   // see also https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/
-  // NOTE: 2.475+ introduced other breaking changes to ecosystem
-  [ platform: 'linux', jdk: '17', jenkins: '2.479.1' ],
-
-  // NOTE: LTS https://www.jenkins.io/changelog-stable/#v2.462.3
-  // is the last LTS release to support Java 11
-  [ platform: 'linux', jdk: '11', jenkins: '2.462.3' ],
-  [ platform: 'linux', jdk: '17', jenkins: '2.462.3' ],
-  [ platform: 'linux', jdk: '21', jenkins: '2.462.3' ],
+  [ platform: 'linux', jdk: '21', jenkins: '2.484' ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <revision>2</revision>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.479.1</jenkins.version>
         <!-- Note: keep in sync with io.jenkins.tools.bom version below -->
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <spotbugs.effort>Max</spotbugs.effort>
@@ -36,8 +36,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>2102.v854b_fec19c92</version>
+                <artifactId>bom-2.479.x</artifactId>
+                <version>3613.v584fca_12cf5c</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
…which requires JDK17+, and perhaps Jakarta EE 9, parent-pom 5.x, Stapler APIv2, etc.

Stay in line with Jenkins ecosystem update and practical deprecation of JDK11 support.