### PR TITLE
Use parent pom 6.2116.x to fix plugin BOM; re-allow Java 17 compile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,10 +5,10 @@
 buildPlugin(useContainerAgent: true, configurations: [
   // Test the common case (i.e., a recent LTS release) on both Linux and Windows
   // with same core version as the lowest baseline requested by pom.xml
-  [ platform: 'linux', jdk: '21', jenkins: '2.484' ],
-  [ platform: 'windows', jdk: '21', jenkins: '2.484' ],
+  [ platform: 'linux', jdk: '17' ],
+  [ platform: 'windows', jdk: '21' ],
 
   // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
   // see also https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/
-  [ platform: 'linux', jdk: '25', jenkins: '2.528.1' ],
+  [ platform: 'linux', jdk: '25', jenkins: '2.541.1' ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>6.2111.v8b_6a_1d599df3</version>
+        <version>6.2116.v7501b_67dc517</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Modeled after https://github.com/jenkinsci/instant-messaging-plugin/pull/308/changes

Thanks @MarkEWaite 