### PR TITLE
OnDemandNoConflicts.java: doCheckConflictsWith(): fix code-scanning warnings

### DIFF
--- a/src/main/java/io/jenkins/plugins/noconflict/OnDemandNoConflicts.java
+++ b/src/main/java/io/jenkins/plugins/noconflict/OnDemandNoConflicts.java
@@ -31,6 +31,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 // Largely based on hudson.slaves.RetentionStrategy.Demand in Jenkins core and https://github.com/jenkinsci/jenkins/pull/5764
 public class OnDemandNoConflicts extends RetentionStrategy<SlaveComputer> {
@@ -240,8 +241,10 @@ public class OnDemandNoConflicts extends RetentionStrategy<SlaveComputer> {
          * @return {@link FormValidation#ok} if this item can be populated as specified, otherwise
          * {@link FormValidation#error} with a message explaining the problem.
          */
+        @POST
         public @NonNull
         FormValidation doCheckConflictsWith(@QueryParameter String value) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             try {
                 Pattern pattern = null;
                 if (value != null && !value.trim().equals("")) {


### PR DESCRIPTION
* Stapler: Missing permission check: Potential missing permission check in `DescriptorImpl#doCheckConflictsWith`
* Stapler: Missing POST/RequirePOST annotation: Potential CSRF vulnerability: If DescriptorImpl#doCheckConflictsWith connects to user-specified URLs, modifies state, or is expensive to run, it should be annotated with @POST or @RequirePOST
